### PR TITLE
Add max-depth command line argument

### DIFF
--- a/tokei_pie/main.py
+++ b/tokei_pie/main.py
@@ -44,7 +44,7 @@ class Sector:
     inaccurate: bool = False
 
 
-def draw(sectors, to_html):
+def draw(sectors, to_html, maxdepth=-1):
     ids = []
     labels = []
     parents = []
@@ -77,6 +77,7 @@ def draw(sectors, to_html):
             branchvalues="total",
             hovertext=hover_texts,
             marker=dict(colors=colors, autocolorscale=True),
+            maxdepth=maxdepth,
         )
     )
     fig.update_layout(
@@ -278,6 +279,13 @@ def main():
         help="don't split directories by language, show aggregate directory sizes",
         action="store_true"
     )
+    parser.add_argument(
+        "--max-depth",
+        type=int,
+        metavar="N",
+        default=-1,
+        help="limit the depth of the sunburst chart (default: -1 for all levels)",
+    )
     args = parser.parse_args()
     if args.verbose == 0:
         pass
@@ -306,7 +314,7 @@ def main():
     logger.info(
         "parse tokei data done, took {:.2f}s".format(parse_file_time - load_time)
     )
-    draw(sectors, args.output_html)
+    draw(sectors, args.output_html, maxdepth=args.max_depth)
     draw_time = time.time()
     logger.info(
         "draw sunburst chart done, took {:.2f}s".format(draw_time - parse_file_time)


### PR DESCRIPTION
This sets the maximum depth the Sunburst chart will render at any one time. Navigating down in the hierarcy shows the additional levels. Defaults to showing all levels, like before.

Setting max-depth is useful for both performance and intelligibility when displaying a very large or deep folder structure.

## With no max-depth
As an example, visualizing [the ngrx platform repo](https://github.com/ngrx/platform) which has a depth of 8 folders below the root (9 levels with the files and I suppose 10 when the languages is inserted as the top level) without setting max-depth, gives us;

<img width="852" height="692" alt="sunburst-unlimited" src="https://github.com/user-attachments/assets/e8e3c8da-7384-4996-ae85-246f4ede60a6" />

After the fifth level, the rings are mostly empty. The few files at last level is very hard to even see. I'm trying to point to JavaScript/projects/ngrx.io/tools/examples/shared/boilerplate/cli/src/karma.conf.js

If I then click on "JavaScript/projects/ngrx.io/tools" we can indeed see everything but the outermost rings are almost completely empty;
<img width="734" height="777" alt="sunburst-unlimited-tools" src="https://github.com/user-attachments/assets/ae3510d1-04ab-4ed4-95bc-965904bde041" />

## With max-depth 5
Doing `tokei -o json | tokei-pie --max-depth 5` instead gives us;

<img width="904" height="884" alt="sunburst-5" src="https://github.com/user-attachments/assets/1ad72ea2-3b6c-4c3a-a8be-5e97aa0a3a10" />

If I then click on "JavaScript/projects/ngrx.io/tools" we get;
<img width="903" height="892" alt="sunburst-5-tools" src="https://github.com/user-attachments/assets/6aa03f50-648e-4caa-9368-5c3c85396658" />

and we're still not showing the last two levels here, but I can select "tools/examples/shared" to see that;

<img width="915" height="837" alt="sunburst-5-shared" src="https://github.com/user-attachments/assets/d2d5e2f2-936b-40c7-94e6-36b1e5a7cbc6" />
